### PR TITLE
Feature/2 endpoint package info no redirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,34 +4,44 @@
   "author": "Sean McIntyre <smcintyre@xverba.ca>",
   "description": "nom is not npm",
   "contributors": [
-    {"name": "Daniela Baron","email": "dbaron@uncharted.software"},
-    {"name": "Michael Laccetti","email": "michael@laccetti.com"},
-    {"name": "Sean McIntyre","email": "s.mcintyre@xverba.ca"}
+    {
+      "name": "Daniela Baron",
+      "email": "dbaron@uncharted.software"
+    },
+    {
+      "name": "Michael Laccetti",
+      "email": "michael@laccetti.com"
+    },
+    {
+      "name": "Sean McIntyre",
+      "email": "s.mcintyre@xverba.ca"
+    }
   ],
-  "license":"MIT",
-  "repository" :{
-    "type" : "git",
-    "url" : "https://github.com/nomjs/nomjs-registry.git"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nomjs/nomjs-registry.git"
   },
-  "main":"dist/app.js",
+  "main": "dist/app.js",
   "scripts": {
     "start": "cd dist && node --harmony-rest-parameters app.js",
-    "test":"gulp test",
-    "debug":"gulp build && cd dist && node --harmony-rest-parameters --debug-brk app.js"
+    "test": "gulp test",
+    "debug": "gulp build && cd dist && node --harmony-rest-parameters --debug-brk app.js"
   },
   "dependencies": {
     "koa-bodyparser": "2.0.1",
-    "ravel":"0.11.0"
+    "ravel": "0.11.0",
+    "request-promise": "^3.0.0"
   },
   "devDependencies": {
-    "babel":"6.3.26",
+    "babel": "6.3.26",
     "babel-eslint": "5.0.0-beta10",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "del": "2.2.0",
     "eslint": "1.10.3",
-    "gulp":"3.9.0",
-    "gulp-babel":"6.1.2",
-    "gulp-sourcemaps":"1.6.0",
+    "gulp": "3.9.0",
+    "gulp-babel": "6.1.2",
+    "gulp-sourcemaps": "1.6.0",
     "run-sequence": "1.1.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,45 +4,37 @@
   "author": "Sean McIntyre <smcintyre@xverba.ca>",
   "description": "nom is not npm",
   "contributors": [
-    {
-      "name": "Daniela Baron",
-      "email": "dbaron@uncharted.software"
-    },
-    {
-      "name": "Michael Laccetti",
-      "email": "michael@laccetti.com"
-    },
-    {
-      "name": "Sean McIntyre",
-      "email": "s.mcintyre@xverba.ca"
-    }
+    {"name": "Daniela Baron","email": "dbaron@uncharted.software"},
+    {"name": "Michael Laccetti","email": "michael@laccetti.com"},
+    {"name": "Sean McIntyre","email": "s.mcintyre@xverba.ca"}
   ],
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/nomjs/nomjs-registry.git"
+  "license":"MIT",
+  "repository" :{
+    "type" : "git",
+    "url" : "https://github.com/nomjs/nomjs-registry.git"
   },
-  "main": "dist/app.js",
+  "main":"dist/app.js",
   "scripts": {
     "start": "cd dist && node --harmony-rest-parameters app.js",
-    "test": "gulp test",
-    "debug": "gulp build && cd dist && node --harmony-rest-parameters --debug-brk app.js"
+    "test":"gulp test",
+    "debug":"gulp build && cd dist && node --harmony-rest-parameters --debug-brk app.js"
   },
   "dependencies": {
-	"github": "0.2.4",
+    "github": "0.2.4",
     "koa-better-body": "2.0.1",
     "ravel": "0.13.0",
-	"rethinkdb": "2.3.1",
-	"request-promise": "^3.0.0"
+    "rethinkdb": "2.3.1",
+    "request-promise": "^3.0.0"
   },
   "devDependencies": {
-    "babel":"6.3.26",
-    "babel-eslint": "5.0.0-beta10",
+    "babel":"6.5.2",
+    "babel-eslint": "6.0.4",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "del": "2.2.0",
-    "eslint": "1.10.3",
-    "gulp":"3.9.0",
+    "eslint": "2.9.0",
+    "gulp":"3.9.1",
     "gulp-babel":"6.1.2",
+    "gulp-eslint": "2.0.0",
     "gulp-sourcemaps":"1.6.0",
     "run-sequence": "1.1.5"
   }

--- a/src/modules/packages.js
+++ b/src/modules/packages.js
@@ -15,6 +15,12 @@ class UnsubmittedPackageError extends Ravel.Error {
   }
 }
 
+class NpmProxyError extends Ravel.Error {
+  constructor(msg) {
+    super(msg, constructor, 500);
+  }
+}
+
 /**
  * Logic for listing, retrieving, publishing packages
  */
@@ -44,14 +50,15 @@ class Packages extends Ravel.Module {
       uri: `https://registry.npmjs.org/${this.encode(id)}`,
       json: true
     };
+
+    this.log.debug(`Proxying to npm: ${rpOptions.uri}`);
     return new Promise((resolve, reject) => {
       rp(rpOptions)
-        .then((response) => {
-          resolve(response);
-        })
+        .then((response) => resolve(response))
         .catch((err) => {
-          // TODO return a specific error like NpmProxyError
-          reject(new Error({error: err}));
+          let errMessage = `Unable to retrieve package info for ${id} from npm`;
+          this.log.error(errMessage, err);
+          reject(new NpmProxyError({error: errMessage}));
         });
     });
   }

--- a/src/modules/packages.js
+++ b/src/modules/packages.js
@@ -38,32 +38,23 @@ class Packages extends Ravel.Module {
     return id.replace('/','%2f');;
   }
 
-  // TODO: make it json instead of text but its actually returning!
+  // TODO env var instead of hard coding registry url?
   _retrieveInfoFromNpm(id) {
+    let rpOptions = {
+      uri: `https://registry.npmjs.org/${this.encode(id)}`,
+      json: true
+    };
     return new Promise((resolve, reject) => {
-      rp(`https://registry.npmjs.org/${this.encode(id)}`)
+      rp(rpOptions)
         .then((response) => {
           resolve(response);
         })
         .catch((err) => {
+          // TODO return a specific error like NpmProxyError
           reject(new Error({error: err}));
         });
     });
   }
-  // _retrieveInfoFromNpm(id) {
-  //   // TODO env var instead of hard coding registry url?
-  //   return rp(`https://registry.npmjs.org/${this.encode(id)}`)
-  //     .then(function(response) {
-  //       console.log('=== NPM PROXY SUCCESS ===');
-  //       return response;
-  //     })
-  //     .catch(function(err) {
-  //       // TODO return a specific error like NpmProxyError
-  //       // return Promise.reject(new Error({error: err}));
-  //       console.log('=== NPM PROXY ERROR ===');
-  //       return new Error({error: err});
-  //     });
-  // }
 
   /**
    * Retrieve package information based on a package name

--- a/src/modules/packages.js
+++ b/src/modules/packages.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Ravel = require('ravel');
+const rp = require('request-promise');
 
 class UnscopedPackageError extends Ravel.Error {
   constructor(msg) {
@@ -37,16 +38,31 @@ class Packages extends Ravel.Module {
     return id.replace('/','%2f');;
   }
 
+  _retrieveInfoFromNpm(id) {
+    // TODO env var instead of hard coding registry url?
+    return rp(`https://registry.npmjs.org/${this.encode(id)}`)
+      .then(function(response) {
+        return Promise.resolve(response);
+      })
+      .catch(function(err) {
+        return Promise.reject(new Error({error: err}));
+      });
+  }
+
   /**
    * Retrieve package information based on a package name
    * @param id {String} the package name (such as @raveljs/ravel).
-   * @return {Promise} resolves if the package is in the nom registry, rejects otherwise
+   * @param query {Object} optional, if specifies proxynpm then will retrieve package info from npm.
+   * @return {Promise} resolves if the package is in the nom registry, rejects otherwise.
    */
-  info(id) {
+  info(id, query) {
+    const opts = query || {};  // no default parameters in node yet
     this.log.info(`client asked for info on: ${id}`);
 
     if (this.isScoped(id)) {
       return this._retrieveInfo(id);
+    } else if (opts.proxynpm) {
+      return this._retrieveInfoFromNpm(id);
     } else {
       return Promise.reject(new UnscopedPackageError({
         error: 'nom does not permit unscoped packages'

--- a/src/modules/packages.js
+++ b/src/modules/packages.js
@@ -38,16 +38,32 @@ class Packages extends Ravel.Module {
     return id.replace('/','%2f');;
   }
 
+  // TODO: make it json instead of text but its actually returning!
   _retrieveInfoFromNpm(id) {
-    // TODO env var instead of hard coding registry url?
-    return rp(`https://registry.npmjs.org/${this.encode(id)}`)
-      .then(function(response) {
-        return Promise.resolve(response);
-      })
-      .catch(function(err) {
-        return Promise.reject(new Error({error: err}));
-      });
+    return new Promise((resolve, reject) => {
+      rp(`https://registry.npmjs.org/${this.encode(id)}`)
+        .then((response) => {
+          resolve(response);
+        })
+        .catch((err) => {
+          reject(new Error({error: err}));
+        });
+    });
   }
+  // _retrieveInfoFromNpm(id) {
+  //   // TODO env var instead of hard coding registry url?
+  //   return rp(`https://registry.npmjs.org/${this.encode(id)}`)
+  //     .then(function(response) {
+  //       console.log('=== NPM PROXY SUCCESS ===');
+  //       return response;
+  //     })
+  //     .catch(function(err) {
+  //       // TODO return a specific error like NpmProxyError
+  //       // return Promise.reject(new Error({error: err}));
+  //       console.log('=== NPM PROXY ERROR ===');
+  //       return new Error({error: err});
+  //     });
+  // }
 
   /**
    * Retrieve package information based on a package name

--- a/src/modules/packages.js
+++ b/src/modules/packages.js
@@ -67,7 +67,8 @@ class Packages extends Ravel.Module {
    * Retrieve package information based on a package name
    * @param id {String} the package name (such as @raveljs/ravel).
    * @param query {Object} optional, if specifies proxynpm then will retrieve package info from npm.
-   * @return {Promise} resolves if the package is in the nom registry, rejects otherwise.
+   * @return {Promise} resolves if the package is in the nom registry, or if proxynpm is requested
+   *                   and the package is found in npm, rejects otherwise.
    */
   info(id, query) {
     const opts = query || {};  // no default parameters in node yet

--- a/src/resources/package.js
+++ b/src/resources/package.js
@@ -20,20 +20,28 @@ class PackageResource extends Resource {
    * Examples:
    *  - https://registry.npmjs.org/ravel
    *  - https://registry.npmjs.org/@raveljs%2fravel
+   *
+   * If a package is in npm and nom should proxy rather than return a redirect:
+   *  - https://registry.npmjs.org/ravel?npmproxy=true
    */
   get(ctx) {
     return this.packages.info(ctx.params.id, ctx.query)
-    .catch((err) => {
-      console.log(err);
-      switch(err.constructor.name) {
-        case 'UnscopedPackageError':
-        case 'UnsubmittedPackageError':
-          ctx.set('Location', `https://registry.npmjs.org/${this.packages.encode(ctx.params.id)}`);
-        default:
-          // rethrow
-          return Promise.reject(err);
-      }
-    });
+      .then((packageInfo) => {
+        // FIXME It is successful, but: Unhandled rejection Error: Can't set headers after they are sent.
+        console.log('=== PACKAGE RESOURCE SUCCESS ===');
+        ctx.status = 200;
+        ctx.body = packageInfo;
+      })
+      .catch((err) => {
+        switch(err.constructor.name) {
+          case 'UnscopedPackageError':
+          case 'UnsubmittedPackageError':
+            ctx.set('Location', `https://registry.npmjs.org/${this.packages.encode(ctx.params.id)}`);
+          default:
+            // rethrow
+            return Promise.reject(err);
+        }
+      });
   }
 
   @before('bodyParser')

--- a/src/resources/package.js
+++ b/src/resources/package.js
@@ -22,8 +22,9 @@ class PackageResource extends Resource {
    *  - https://registry.npmjs.org/@raveljs%2fravel
    */
   get(ctx) {
-    return this.packages.info(ctx.params.id)
+    return this.packages.info(ctx.params.id, ctx.query)
     .catch((err) => {
+      console.log(err);
       switch(err.constructor.name) {
         case 'UnscopedPackageError':
         case 'UnsubmittedPackageError':

--- a/src/resources/package.js
+++ b/src/resources/package.js
@@ -27,8 +27,6 @@ class PackageResource extends Resource {
   get(ctx) {
     return this.packages.info(ctx.params.id, ctx.query)
       .then((packageInfo) => {
-        // FIXME It is successful, but: Unhandled rejection Error: Can't set headers after they are sent.
-        console.log('=== PACKAGE RESOURCE SUCCESS ===');
         ctx.status = 200;
         ctx.body = packageInfo;
       })


### PR DESCRIPTION
@Ghnuberath 

Adds support for query string on package info endpoint `?proxynpm=true`.

If this is set and its an unscoped package, then rather than returning a redirect to npm registry, it will proxy the request, using [request-promise](https://github.com/request/request-promise).

This is in support of search website [feature](https://github.com/nomjs/nomjs-search-website/issues/7). See [sample usage](https://github.com/nomjs/nomjs-search-website/blob/feature/7-package-details-view/src/package/package-service.js#L18).

Fixes #2 
